### PR TITLE
Memory allocation optimizations (in DH and Embeddium compat)

### DIFF
--- a/src/main/java/com/teamtea/eclipticseasons/compat/distanthorizons/DHTool.java
+++ b/src/main/java/com/teamtea/eclipticseasons/compat/distanthorizons/DHTool.java
@@ -1,10 +1,9 @@
 package com.teamtea.eclipticseasons.compat.distanthorizons;
 
-import com.seibel.distanthorizons.common.wrappers.McObjectConverter_forge;
-import com.seibel.distanthorizons.common.wrappers.block.BiomeWrapper_forge;
 import com.seibel.distanthorizons.common.wrappers.block.BlockStateWrapper_forge;
 import com.seibel.distanthorizons.common.wrappers.world.ClientLevelWrapper_forge;
 import com.seibel.distanthorizons.core.dataObjects.fullData.FullDataPointIdMap;
+import com.seibel.distanthorizons.core.dataObjects.fullData.sources.FullDataSourceV2;
 import com.seibel.distanthorizons.core.pos.blockPos.DhBlockPos;
 import com.seibel.distanthorizons.core.pos.blockPos.DhBlockPosMutable;
 import com.seibel.distanthorizons.core.util.FullDataPointUtil;
@@ -21,9 +20,6 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Blocks;
@@ -32,147 +28,185 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.material.MapColor;
 
-import java.util.HashSet;
-
 public class DHTool {
+    private static final ThreadLocal<BlockPos.MutableBlockPos> MUTABLE_BLOCK_POS = ThreadLocal.withInitial(BlockPos.MutableBlockPos::new);
 
-    public static MapColor computeBaseColor(IClientLevelWrapper instance, DhBlockPos dhBlockPos, IBiomeWrapper iBiomeWrapper, IBlockStateWrapper iBlockStateWrapper, FullDataPointIdMap fullDataMapping, LongArrayList fullColumnData, IWrapperFactory WRAPPER_FACTORY, int skyLight) {
-        if (!CompatModule.CommonConfig.DistantHorizonsWinterLOD.get()) return null;
+    public static MapColor computeBaseColor(IClientLevelWrapper instance, DhBlockPos dhBlockPos, IBiomeWrapper iBiomeWrapper, IBlockStateWrapper iBlockStateWrapper,  FullDataSourceV2 fullDataSource, LongArrayList fullColumnData,  IWrapperFactory WRAPPER_FACTORY) {
+        if (!CompatModule.CommonConfig.DistantHorizonsWinterLOD.get()
+                || !CommonConfig.isSnowyWinter()
+                || dhBlockPos.equals(DhBlockPos.ZERO)
+                || !(iBlockStateWrapper instanceof BlockStateWrapper_forge forgeBlockState)
+                || forgeBlockState.isAir()) {
+            return null;
+        }
 
-        if (CommonConfig.isSnowyWinter()) {
-            if (!dhBlockPos.equals(DhBlockPos.ZERO)
-                    && iBlockStateWrapper instanceof BlockStateWrapper_forge blockStateWrapper
-                    && !blockStateWrapper.isAir()
-                    && skyLight > 0
-            ) {
-                var mcPos = convert(dhBlockPos);
-                var level = ClientCon.getUseLevel();
-                var blockState = blockStateWrapper.blockState;
-                // 当给的pos未加载时，读取的是虚空，这并不好。
-                if (instance instanceof ClientLevelWrapper_forge clientLevelWrapper) {
-                    var holderKey = ResourceKey.create(Registries.BIOME, new ResourceLocation(iBiomeWrapper.getSerialString()));
-                    Holder.Reference<Biome> holder = clientLevelWrapper.getLevel().registryAccess().registryOrThrow(Registries.BIOME).getHolderOrThrow(holderKey);
-                    // if ((holderOrThrow
-                    //         instanceof Holder.Reference<Biome> holder))
-                    {
+        int targetDataIndex = findDataPointIndex(instance, dhBlockPos, fullColumnData);
 
-                        if (MapChecker.shouldSnowAtBiome(level, holder.value(), blockState, level.getRandom(), blockState.getSeed(mcPos), mcPos))
-                        //     return mapColor.col;
-                        {
-                            ObjectOpenHashSet<IBlockStateWrapper> blockStatesToIgnore = WRAPPER_FACTORY.getRendererIgnoredBlocks(instance);
-                            for (int i = 0; i < fullColumnData.size(); i++) {
-                                long fullData = fullColumnData.getLong(i);
-                                int id = FullDataPointUtil.getId(fullData);
-                                IBlockStateWrapper iBlockStateWrapper_NowQuery;
-                                try {
-                                    iBlockStateWrapper_NowQuery = fullDataMapping.getBlockStateWrapper(id);
-                                } catch (IndexOutOfBoundsException e) {
-                                    continue;
-                                }
-                                int bottomY = FullDataPointUtil.getBottomY(fullData);
-                                int blockHeight = FullDataPointUtil.getHeight(fullData);
-                                int topY = bottomY + blockHeight;
-                                if (CommonConfig.Debug.notLightAbove.get()
-                                        && iBlockStateWrapper_NowQuery instanceof BlockStateWrapper_forge blockStateWrapper_NowQuery) {
-                                    if (blockStateWrapper_NowQuery.blockState != null &&
-                                            blockStateWrapper_NowQuery.blockState.getBlock() instanceof LightBlock) {
-                                        if (blockStateWrapper_NowQuery.blockState.hasProperty(LightBlock.LEVEL)
-                                                && blockStateWrapper_NowQuery.blockState.getValue(LightBlock.LEVEL) == 0)
-                                            break;
-                                    }
-                                }
+        if (targetDataIndex < 0 || FullDataPointUtil.getSkyLight(fullColumnData.getLong(targetDataIndex)) <= 0) {
+            return null;
+        }
 
-                                if (iBlockStateWrapper_NowQuery instanceof BlockStateWrapper_forge blockStateWrapper_NowQuery
-                                        && !iBlockStateWrapper_NowQuery.isAir()
-                                        && !blockStatesToIgnore.contains(iBlockStateWrapper_NowQuery)
-                                ) {
+        Biome biome = unwrapBiome(iBiomeWrapper);
+        if (!(instance instanceof ClientLevelWrapper_forge) || biome == null) {
+            return null;
+        }
 
-                                    if (bottomY + instance.getMinHeight() == dhBlockPos.getY() &&
-                                            (MapChecker.getDefaultBlockTypeFlag(blockStateWrapper_NowQuery.blockState) != 0
-                                                    // || (blockStateWrapper1.blockState.is(BlockTags.FLOWERS))
-                                                    || (!blockStateWrapper_NowQuery.isSolid() && !blockStateWrapper_NowQuery.isLiquid())
-                                            )) {
-                                        // return Color.WHITE.getRGB();
-                                        return MapColor.SNOW;
-                                    } else {
-                                        if (!blockStateWrapper_NowQuery.isLiquid()
-                                                && !blockStateWrapper_NowQuery.blockState.blocksMotion()) {
-                                            // 如果colorBelowWithAvoidedBlocks时，这时会查看下面的方块，我们也进行一个染色
-                                            // 暂时不处理多层需要跳过的方块，实际上也许保留一点颜色会更好看
-                                            if (i + 1 < fullColumnData.size()) {
-                                                int belowBottomY = FullDataPointUtil.getBottomY(fullColumnData.getLong(i + 1));
-                                                if (belowBottomY + instance.getMinHeight() == dhBlockPos.getY())
-                                                    return MapColor.SNOW;
-                                            }
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+        BlockPos.MutableBlockPos mcPos = mutableBlockPos(dhBlockPos);
+        Level level = ClientCon.getUseLevel();
+        BlockState blockState = forgeBlockState.blockState;
 
+        if (!MapChecker.shouldSnowAtBiome(
+                level,
+                biome,
+                blockState,
+                level.getRandom(),
+                blockState.getSeed(mcPos),
+                mcPos)) {
+            return null;
+        }
 
+        FullDataPointIdMap fullDataMapping = fullDataSource.mapping;
+        ObjectOpenHashSet<IBlockStateWrapper> blockStatesToIgnore = WRAPPER_FACTORY.getRendererIgnoredBlocks(instance);
+
+        for (int i = 0; i <= targetDataIndex; i++) {
+            long fullData = fullColumnData.getLong(i);
+            int id = FullDataPointUtil.getId(fullData);
+
+            IBlockStateWrapper queriedWrapper;
+            try {
+                queriedWrapper = fullDataMapping.getBlockStateWrapper(id);
+            } catch (IndexOutOfBoundsException ignored) {
+                continue;
+            }
+
+            if (CommonConfig.Debug.notLightAbove.get()
+                    && queriedWrapper
+                    instanceof BlockStateWrapper_forge queriedForgeState
+                    && queriedForgeState.blockState != null
+                    && queriedForgeState.blockState.getBlock()
+                    instanceof LightBlock
+                    && queriedForgeState.blockState.hasProperty(
+                    LightBlock.LEVEL
+            )
+                    && queriedForgeState.blockState.getValue(
+                    LightBlock.LEVEL
+            ) == 0) {
+                break;
+            }
+
+            if (!(queriedWrapper instanceof BlockStateWrapper_forge queriedForgeState)
+                    || queriedWrapper.isAir()
+                    || blockStatesToIgnore.contains(queriedWrapper)) {
+                continue;
+            }
+
+            if (i == targetDataIndex
+                    && (MapChecker.getDefaultBlockTypeFlag(
+                    queriedForgeState.blockState
+            ) != 0
+                    || (!queriedWrapper.isSolid()
+                    && !queriedWrapper.isLiquid()))) {
+                return MapColor.SNOW;
+            }
+
+            if (!queriedWrapper.isLiquid() && !queriedForgeState.blockState.blocksMotion()) {
+                if (i + 1 == targetDataIndex) {
+                    return MapColor.SNOW;
                 }
+
+                break;
             }
         }
+
         return null;
     }
 
-    public static Biome recoverBiomeObject(BiomeWrapper_forge biomeWrapper, IClientLevelWrapper iClientLevelWrapper) {
-        if (!CompatModule.CommonConfig.DistantHorizonsWinterLOD.get()) return null;
-        // if (iClientLevelWrapper instanceof ClientLevelWrapper clientLevelWrapper) {
-        //     var holderKey = ResourceKey.create(Registries.BIOME, ResourceLocation.parse(biomeWrapper.getSerialString()));
-        //     if ((clientLevelWrapper.getLevel().registryAccess().holder(holderKey).orElse(null)
-        //             instanceof Holder.Reference<Biome> holder)) {
-        //         // if (BiomeWrapper.getBiomeWrapper(holder, clientLevelWrapper) instanceof BiomeWrapper biomeWrapper1)
-        //         return holder.value();
-        //     }
-        // }
-        return null;
-    }
+    private static int findDataPointIndex(
+            IClientLevelWrapper instance,
+            DhBlockPos dhBlockPos,
+            LongArrayList fullColumnData) {
+        int targetBottomY =
+                dhBlockPos.getY() - instance.getMinHeight();
 
-    //public static void clearRenderCache() {
-    //    if (!CompatModule.CommonConfig.DistantHorizonsWinterLOD.get()) return;
-    //    IDhClientWorld clientWorld = SharedApi.getIDhClientWorld();
-    //    if (Minecraft.getInstance().level != null
-    //            && ClientLevelWrapper.getWrapper(Minecraft.getInstance().level) instanceof ClientLevelWrapper clientLevelWrapper
-    //            && clientWorld.getLevel(clientLevelWrapper) instanceof IDhClientLevel clientLevel) {
-    //        clientLevel.clearRenderCache();
-    //    }
-    //}
+        int low = 0;
+        int high = fullColumnData.size() - 1;
+
+        while (low <= high) {
+            int middle = (low + high) >>> 1;
+
+            int middleBottomY = FullDataPointUtil.getBottomY(
+                    fullColumnData.getLong(middle)
+            );
+
+            if (middleBottomY == targetBottomY) {
+                return middle;
+            }
+
+            if (middleBottomY > targetBottomY) {
+                low = middle + 1;
+            } else {
+                high = middle - 1;
+            }
+        }
+
+        return -1;
+    }
 
     public static IBlockStateWrapper shouldFrozen(ClientLevelWrapper_forge instance, IBiomeWrapper biomeWrapper, DhBlockPosMutable dhBlockPosMutable, BlockState blockState, FullDataPointIdMap fullDataMapping, LongArrayList fullColumnData, int index) {
-        if (!CompatModule.CommonConfig.DistantHorizonsWinterLOD.get()) return null;
+        if (!CompatModule.CommonConfig.DistantHorizonsWinterLOD.get()) {
+            return null;
+        }
+
+        Biome biome = unwrapBiome(biomeWrapper);
 
         if (ClientConfig.Debug.frozenWater.get()
-                && biomeWrapper.getWrappedMcObject() instanceof Holder<?> holder
-                && holder.value() instanceof Biome biome
+                && biome != null
                 && blockState.is(Blocks.WATER)
-                && blockState.getFluidState().isSourceOfType(Fluids.WATER)) {
+                && blockState.getFluidState()
+                .isSourceOfType(Fluids.WATER)) {
             if (index > 0 && index < fullColumnData.size() - 1) {
                 try {
-                    int id = FullDataPointUtil.getId(fullColumnData.getLong(index - 1));
-                    if (!fullDataMapping.getBlockStateWrapper(id).isAir())
+                    int id = FullDataPointUtil.getId(
+                            fullColumnData.getLong(index - 1)
+                    );
+
+                    if (!fullDataMapping
+                            .getBlockStateWrapper(id)
+                            .isAir()) {
                         return null;
+                    }
                 } catch (IndexOutOfBoundsException ignored) {
                 }
             }
-            var mcPos = convert(dhBlockPosMutable);
+
+            BlockPos.MutableBlockPos mcPos = mutableBlockPos(dhBlockPosMutable);
             Level level = instance.getLevel();
-            if (MapChecker.shouldSnowAtBiome(level, biome, blockState, level.getRandom(), blockState.getSeed(mcPos), mcPos)) {
-                return BlockStateWrapper_forge.fromBlockState(Blocks.ICE.defaultBlockState(), instance);
+
+            if (MapChecker.shouldSnowAtBiome(
+                    level,
+                    biome,
+                    blockState,
+                    level.getRandom(),
+                    blockState.getSeed(mcPos),
+                    mcPos)) {
+                return BlockStateWrapper_forge.fromBlockState(
+                        Blocks.ICE.defaultBlockState(),
+                        instance
+                );
             }
         }
         return null;
     }
 
-    /**
-     * From {@link com.seibel.distanthorizons.common.wrappers.McObjectConverter#convert(DhBlockPos)}.
-     * As it changed its signature.
-     *
-     */
-    public static BlockPos convert(DhBlockPos wrappedPos) {
-        return new BlockPos(wrappedPos.getX(), wrappedPos.getY(), wrappedPos.getZ());
+    private static Biome unwrapBiome(IBiomeWrapper biomeWrapper) {
+        Object wrappedBiome = biomeWrapper.getWrappedMcObject();
+        if (wrappedBiome instanceof Holder<?> holder && holder.value() instanceof Biome biome) {
+            return biome;
+        }
+        return wrappedBiome instanceof Biome biome ? biome : null;
+    }
+
+    private static BlockPos.MutableBlockPos mutableBlockPos(DhBlockPos wrappedPos) {
+        return MUTABLE_BLOCK_POS.get().set(wrappedPos.getX(), wrappedPos.getY(), wrappedPos.getZ());
     }
 }

--- a/src/main/java/com/teamtea/eclipticseasons/mixin/client/biome/MixinClientBiome.java
+++ b/src/main/java/com/teamtea/eclipticseasons/mixin/client/biome/MixinClientBiome.java
@@ -1,42 +1,31 @@
 package com.teamtea.eclipticseasons.mixin.client.biome;
 
-
-import com.teamtea.eclipticseasons.api.misc.IBiomeTagHolder;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.teamtea.eclipticseasons.client.color.season.BiomeColorsHandler;
 import net.minecraft.world.level.biome.Biome;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin({Biome.class})
+@Mixin(Biome.class)
 public abstract class MixinClientBiome {
 
-    @Inject(at = {@At("RETURN")}, method = {"getSkyColor"}, cancellable = true)
-    public void eclipticseasons$getSkyColor(CallbackInfoReturnable<Integer> cir) {
-        int returnValue = cir.getReturnValue();
-        int skyColor = BiomeColorsHandler.getSkyColor((Biome) (Object) this, returnValue);
-        if (returnValue != skyColor) cir.setReturnValue(skyColor);
+    @ModifyReturnValue(method = "getSkyColor", at = @At("RETURN"))
+    private int eclipticseasons$getSkyColor(int original) {
+        return BiomeColorsHandler.getSkyColor((Biome) (Object) this, original);
     }
 
-    @Inject(at = {@At("RETURN")}, method = {"getWaterColor"}, cancellable = true)
-    public void eclipticseasons$getWaterColor(CallbackInfoReturnable<Integer> cir) {
-        int returnValue = cir.getReturnValue();
-        int waterColor = BiomeColorsHandler.getWaterColor((Biome) (Object) this, returnValue);
-        if (returnValue != waterColor) cir.setReturnValue(waterColor);
+    @ModifyReturnValue(method = "getWaterColor", at = @At("RETURN"))
+    private int eclipticseasons$getWaterColor(int original) {
+        return BiomeColorsHandler.getWaterColor((Biome) (Object) this, original);
     }
 
-    @Inject(at = {@At("RETURN")}, method = {"getWaterFogColor"}, cancellable = true)
-    public void eclipticseasons$getWaterFogColor(CallbackInfoReturnable<Integer> cir) {
-        int returnValue = cir.getReturnValue();
-        int waterFogColor = BiomeColorsHandler.getWaterFogColor((Biome) (Object) this, returnValue);
-        if (returnValue != waterFogColor) cir.setReturnValue(waterFogColor);
+    @ModifyReturnValue(method = "getWaterFogColor", at = @At("RETURN"))
+    private int eclipticseasons$getWaterFogColor(int original) {
+        return BiomeColorsHandler.getWaterFogColor((Biome) (Object) this, original);
     }
 
-    @Inject(at = {@At("RETURN")}, method = {"getFogColor"}, cancellable = true)
-    public void eclipticseasons$getFogColor(CallbackInfoReturnable<Integer> cir) {
-        int returnValue = cir.getReturnValue();
-        int fogColor = BiomeColorsHandler.getFogColor((Biome) (Object) this, returnValue);
-        if (returnValue != fogColor) cir.setReturnValue(fogColor);
+    @ModifyReturnValue(method = "getFogColor", at = @At("RETURN"))
+    private int eclipticseasons$getFogColor(int original) {
+        return BiomeColorsHandler.getFogColor((Biome) (Object) this, original);
     }
 }

--- a/src/main/java/com/teamtea/eclipticseasons/mixin/compat/distanthorizons/MixinFullDataToRenderDataTransformer.java
+++ b/src/main/java/com/teamtea/eclipticseasons/mixin/compat/distanthorizons/MixinFullDataToRenderDataTransformer.java
@@ -1,15 +1,12 @@
 package com.teamtea.eclipticseasons.mixin.compat.distanthorizons;
 
-
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
-import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
 import com.seibel.distanthorizons.common.wrappers.world.ClientLevelWrapper_forge;
 import com.seibel.distanthorizons.core.dataObjects.fullData.FullDataPointIdMap;
 import com.seibel.distanthorizons.core.dataObjects.fullData.sources.FullDataSourceV2;
+import com.seibel.distanthorizons.core.dataObjects.render.columnViews.ColumnRenderView;
 import com.seibel.distanthorizons.core.dataObjects.transformers.FullDataToRenderDataTransformer;
-import com.seibel.distanthorizons.core.pos.blockPos.DhBlockPos;
 import com.seibel.distanthorizons.core.pos.blockPos.DhBlockPosMutable;
 import com.seibel.distanthorizons.core.wrapperInterfaces.IWrapperFactory;
 import com.seibel.distanthorizons.core.wrapperInterfaces.block.IBlockStateWrapper;
@@ -28,7 +25,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import java.awt.*;
 
 @Pseudo
-@Mixin({FullDataToRenderDataTransformer.class})
+@Mixin(FullDataToRenderDataTransformer.class)
 public abstract class MixinFullDataToRenderDataTransformer {
 
 
@@ -36,52 +33,51 @@ public abstract class MixinFullDataToRenderDataTransformer {
     @Final
     private static IWrapperFactory WRAPPER_FACTORY;
 
-    @WrapOperation(
+    @ModifyExpressionValue(
             remap = false,
-            require = 0,
+            require = 1,
+            expect = 4,
             method = "setRenderColumnView",
             at = @At(value = "INVOKE", target = "Lcom/seibel/distanthorizons/core/wrapperInterfaces/world/IClientLevelWrapper;getBlockColor(Lcom/seibel/distanthorizons/core/pos/blockPos/DhBlockPos;Lcom/seibel/distanthorizons/core/wrapperInterfaces/world/IBiomeWrapper;Lcom/seibel/distanthorizons/core/dataObjects/fullData/sources/FullDataSourceV2;Lcom/seibel/distanthorizons/core/wrapperInterfaces/block/IBlockStateWrapper;)I")
     )
-    private static int eclipticseasons$setRenderColumnView_computeBaseColor(IClientLevelWrapper instance,
-                                                                            DhBlockPos dhBlockPos,
-                                                                            IBiomeWrapper iBiomeWrapper,
+    private static int eclipticseasons$setRenderColumnView_computeBaseColor(int original,
+                                                                            IClientLevelWrapper enclosingLevelWrapper,
                                                                             FullDataSourceV2 fullDataSourceV2,
-                                                                            IBlockStateWrapper iBlockStateWrapper,
-                                                                            Operation<Integer> original,
-                                                                            @Local FullDataPointIdMap fullDataMapping,
-                                                                            @Local(argsOnly = true) LongArrayList fullColumnData,
-                                                                            @Local(name = "skyLight") LocalIntRef localIntRef) {
-        MapColor mapColor = DHTool.computeBaseColor(instance, dhBlockPos, iBiomeWrapper, iBlockStateWrapper, fullDataMapping, fullColumnData, WRAPPER_FACTORY,localIntRef.get());
+                                                                            int blockX,
+                                                                            int blockZ,
+                                                                            ColumnRenderView renderColumnData,
+                                                                            LongArrayList fullColumnData,
+                                                                            @Local(name = "mutableBlockPos") DhBlockPosMutable mutableBlockPos,
+                                                                            @Local(name = "biome") IBiomeWrapper iBiomeWrapper,
+                                                                            @Local(name = "block") IBlockStateWrapper iBlockStateWrapper) {
+        MapColor mapColor = DHTool.computeBaseColor(enclosingLevelWrapper, mutableBlockPos, iBiomeWrapper, iBlockStateWrapper, fullDataSourceV2, fullColumnData, WRAPPER_FACTORY);
         if (mapColor == MapColor.SNOW)
             // 不知道为什么，不能用这个值
             return Color.WHITE.getRGB();
-        return original.call(instance, dhBlockPos, iBiomeWrapper, fullDataSourceV2, iBlockStateWrapper);
+        return original;
     }
 
 
-    @WrapOperation(
+    @ModifyExpressionValue(
             remap = false,
             require = 0,
             method = "setRenderColumnView",
             at = @At(value = "INVOKE", target = "Lcom/seibel/distanthorizons/core/dataObjects/fullData/FullDataPointIdMap;getBlockStateWrapper(I)Lcom/seibel/distanthorizons/core/wrapperInterfaces/block/IBlockStateWrapper;")
     )
     private static IBlockStateWrapper eclipticseasons$setRenderColumnView_fixIce(
-            FullDataPointIdMap instance,
-            int id,
-            Operation<IBlockStateWrapper> original,
+            IBlockStateWrapper original,
             @Local(argsOnly = true) IClientLevelWrapper clientLevel,
             @Local FullDataPointIdMap fullDataMapping,
             @Local(argsOnly = true) LongArrayList fullColumnData,
             @Local DhBlockPosMutable dhBlockPosMutable,
             @Local IBiomeWrapper biomeWrapper,
-            @Local(name = "fullDataIndex") LocalIntRef localIntRef) {
-        IBlockStateWrapper call = original.call(instance, id);
-        if (call.isLiquid() && call.getWrappedMcObject() instanceof BlockState blockState
+            @Local(name = "fullDataIndex") int fullDataIndex) {
+        if (original.isLiquid() && original.getWrappedMcObject() instanceof BlockState blockState
                 && clientLevel instanceof ClientLevelWrapper_forge clientLevelWrapper) {
-            IBlockStateWrapper warp = DHTool.shouldFrozen(clientLevelWrapper, biomeWrapper, dhBlockPosMutable, blockState, fullDataMapping, fullColumnData, localIntRef.get());
-            if (warp != null) call = warp;
+            IBlockStateWrapper frozen = DHTool.shouldFrozen(clientLevelWrapper, biomeWrapper, dhBlockPosMutable, blockState, fullDataMapping, fullColumnData, fullDataIndex);
+            if (frozen != null) return frozen;
         }
-        return call;
-    }
 
+        return original;
+    }
 }

--- a/src/main/java/com/teamtea/eclipticseasons/mixin/compat/embeddium/MixinBlockRenderTask.java
+++ b/src/main/java/com/teamtea/eclipticseasons/mixin/compat/embeddium/MixinBlockRenderTask.java
@@ -3,36 +3,24 @@ package com.teamtea.eclipticseasons.mixin.compat.embeddium;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
-import com.llamalad7.mixinextras.sugar.ref.LocalRef;
-import com.teamtea.eclipticseasons.api.constant.tag.EclipticBlockTags;
 import com.teamtea.eclipticseasons.api.misc.client.IExtraRendererContextOwner;
-import com.teamtea.eclipticseasons.api.misc.client.IMapSlice;
 import com.teamtea.eclipticseasons.client.core.ExtraRendererContext;
 import com.teamtea.eclipticseasons.client.core.ExtraModelManager;
-import com.teamtea.eclipticseasons.client.model.ISnowyReplaceModel;
 import com.teamtea.eclipticseasons.client.render.chunk.IceKeeper;
-import com.teamtea.eclipticseasons.client.util.ClientCon;
-import com.teamtea.eclipticseasons.common.core.biome.WeatherManager;
-import com.teamtea.eclipticseasons.common.core.map.MapChecker;
 import com.teamtea.eclipticseasons.compat.iris.IIrisShaderAccesor;
 import com.teamtea.eclipticseasons.compat.vanilla.IExtendBlockView;
-import it.unimi.dsi.fastutil.HashCommon;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildBuffers;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildContext;
-import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildOutput;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderCache;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderContext;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.tasks.ChunkBuilderMeshingTask;
-import me.jellysquid.mods.sodium.client.util.task.CancellationToken;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.LeavesBlock;
 import net.minecraft.world.level.block.SnowLayerBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
@@ -41,8 +29,8 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin({ChunkBuilderMeshingTask.class})
 public abstract class MixinBlockRenderTask {
@@ -51,25 +39,21 @@ public abstract class MixinBlockRenderTask {
     @Final
     private RandomSource random;
 
-
-    @Inject(
+    @ModifyArg(
             // remap = false,
             method = "execute(Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildContext;Lme/jellysquid/mods/sodium/client/util/task/CancellationToken;)Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildOutput;",
+            index = 0,
             at = @At(value = "INVOKE",
                     // shift = At.Shift.AFTER,
                     ordinal = 1,
                     target = "Lnet/minecraft/util/RandomSource;setSeed(J)V")
     )
-    private void eclipticseasons$execute_findModel(
-            ChunkBuildContext buildContext, CancellationToken cancellationToken, CallbackInfoReturnable<ChunkBuildOutput> cir,
+    private long eclipticseasons$execute_findModel(
+            long seed,
             @Local BakedModel bakedModel,
             @Local BlockRenderContext ctx,
-            @Local ChunkBuildBuffers buffers,
-            @Local BlockRenderCache cache,
             @Local(ordinal = 0) BlockPos.MutableBlockPos mutableBlockPos,
-            @Local(ordinal = 1) BlockPos.MutableBlockPos mutableBlockPos2,
             @Local(ordinal = 0) BlockState state,
-            @Local long seed,
             @Local ModelData modelData
     ) {
         random.setSeed(seed);
@@ -82,6 +66,7 @@ public abstract class MixinBlockRenderTask {
                 .setExtraModel(model)
                 .setReplace(model != null
                         && ExtraModelManager.isModelReplaceable(state, ctx.world(), mutableBlockPos, model));
+        return seed;
     }
 
     @ModifyExpressionValue(
@@ -162,38 +147,31 @@ public abstract class MixinBlockRenderTask {
         return original;
     }
 
-
-    @Inject(
+    @ModifyVariable(
             remap = false,
+            ordinal = 0,
             method = "execute(Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildContext;Lme/jellysquid/mods/sodium/client/util/task/CancellationToken;)Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildOutput;",
             at = @At(value = "INVOKE",
                     // shift = At.Shift.AFTER,
                     target = "Lme/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderCache;getBlockModels()Lnet/minecraft/client/renderer/block/BlockModelShaper;")
     )
-    private void eclipticseasons$renderSnowLayerIn_below(
-            ChunkBuildContext buildContext,
-            CancellationToken cancellationToken,
-            CallbackInfoReturnable<ChunkBuildOutput> cir,
+    private BlockState eclipticseasons$renderSnowLayerIn_below(
+            BlockState state,
             @Local BlockRenderContext ctx,
-            @Local(ordinal = 0) BlockPos.MutableBlockPos mutableBlockPos,
-            @Local LocalRef<BlockState> stateLocalRef
+            @Local(ordinal = 0) BlockPos.MutableBlockPos mutableBlockPos
     ) {
-        var state = ExtraModelManager.shouldBlockAsSnowyState(stateLocalRef.get(), ctx.localSlice(), mutableBlockPos);
-        if (state != stateLocalRef.get())
-            stateLocalRef.set(state);
+        return ExtraModelManager.shouldBlockAsSnowyState(state, ctx.localSlice(), mutableBlockPos);
     }
-
-    @Inject(
+    @ModifyArg(
             //remap = false,
+            index = 0,
             method = "execute(Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildContext;Lme/jellysquid/mods/sodium/client/util/task/CancellationToken;)Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildOutput;",
             at = @At(value = "INVOKE",
                     // shift = At.Shift.AFTER,
                     target = "Lnet/minecraft/world/level/block/state/BlockState;isSolidRender(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Z")
     )
-    private void eclipticseasons$renderSnowLayerIn(
-            ChunkBuildContext buildContext,
-            CancellationToken cancellationToken,
-            CallbackInfoReturnable<ChunkBuildOutput> cir,
+    private BlockGetter eclipticseasons$renderSnowLayerIn(
+            BlockGetter blockGetter,
             @Local BlockRenderContext ctx,
             @Local ChunkBuildBuffers buffers,
             @Local BlockRenderCache cache,
@@ -215,25 +193,22 @@ public abstract class MixinBlockRenderTask {
                     RenderType.solid());
             cache.getBlockRenderer().renderModel(ctx, buffers);
         }
+        return blockGetter;
     }
-
-    @Inject(
+    @ModifyArg(
             method = "execute(Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildContext;Lme/jellysquid/mods/sodium/client/util/task/CancellationToken;)Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildOutput;",
             remap = false,
+            index = 1,
             at = @At(value = "INVOKE", target = "Lme/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/FluidRenderer;render(Lme/jellysquid/mods/sodium/client/world/WorldSlice;Lnet/minecraft/world/level/material/FluidState;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos;Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers;)V")
     )
-    private void eclipticseasons$renderFrozenWaterIce(ChunkBuildContext buildContext,
-                                                      CancellationToken cancellationToken,
-                                                      CallbackInfoReturnable<ChunkBuildOutput> cir,
-                                                      @Local BlockRenderContext ctx,
-                                                      @Local ChunkBuildBuffers buffers,
-                                                      @Local FluidState fluidState,
-                                                      @Local BlockState blockState,
-                                                      @Local(ordinal = 0) BlockPos.MutableBlockPos blockPos,
-                                                      @Local(ordinal = 1) BlockPos.MutableBlockPos modelOffset) {
-
-
-        if (IceKeeper.notFrozen(buildContext.cache.getWorldSlice(), blockPos, blockState, fluidState)) return;
+    private FluidState eclipticseasons$renderFrozenWaterIce(FluidState fluidState,
+                                                            @Local BlockRenderContext ctx,
+                                                            @Local ChunkBuildBuffers buffers,
+                                                            @Local BlockRenderCache cache,
+                                                            @Local(ordinal = 0) BlockState blockState,
+                                                            @Local(ordinal = 0) BlockPos.MutableBlockPos blockPos,
+                                                            @Local(ordinal = 1) BlockPos.MutableBlockPos modelOffset) {
+        if (IceKeeper.notFrozen(cache.getWorldSlice(), blockPos, blockState, fluidState)) return fluidState;
         BakedModel model = IceKeeper.getIceModel(blockState, fluidState);
         if (model != null) {
             BlockState fakeState = IceKeeper.getFakeState(blockState, fluidState);
@@ -244,8 +219,9 @@ public abstract class MixinBlockRenderTask {
                     blockState.getSeed(blockPos),
                     ModelData.EMPTY,
                     ExtraModelManager.getRenderType(fakeState));
-            buildContext.cache.getBlockRenderer().renderModel(ctx, buffers);
+            cache.getBlockRenderer().renderModel(ctx, buffers);
         }
+        return fluidState;
     }
 
 }


### PR DESCRIPTION
I really love this mod :) Great work!

One thing I noticed was that it increased Garbage Collection pressure in my modpack quite a lot. To be fair, that may not be as much of an issue in a more lightweight pack, or without Distant Horizons/Embeddium.

The main cause are the Mixins used. Callback based mixins like `@Inject` allocate `CallbackInfoReturnable<>` objects for every call made. In hot paths, this quickly accumulates, and the Biome, Distant Horizons and Embeddium Mixins touch super hot paths. So the main change here is changing to Mixin types that are based on primitives and don't allocate callback objects. A good example is this commit: https://github.com/TeamTeaMC/Ecliptic-Seasons/pull/185/changes/1c11c95c47559738942241820a53ffe8475166d0

There are similar issues with many `LocalRef `, `BlockPos` etc. allocations, sometimes where values could be cached, used directly instead of allocating new objects, or could be using a mutable block position object over creating immutable ones each time. Another example is switching from:

```java
public static BlockPos convert(DhBlockPos wrappedPos) {
    return new BlockPos(wrappedPos.getX(), wrappedPos.getY(), wrappedPos.getZ())
}
```

To:
```java
private static BlockPos.MutableBlockPos mutableBlockPos(DhBlockPos wrappedPos) {
    return MUTABLE_BLOCK_POS.get().set(wrappedPos.getX(), wrappedPos.getY(), wrappedPos.getZ());
}
```

I've tried to keep the changes simple and self-contained. I also split the optimization into separate commits; each one is separate and should be usable on its own. I suggest reviewing the commits separately.

I did quite a bit of testing, including switching between snow and non-snow seasons. Everything seems to work, and GC pressure has been reduced by ~75% in my modpack. *A lot* of it was `CallbackInfoReturnable<>` allocations by these compat mixins.

